### PR TITLE
Replaced `&` with `$` which was messing up codegen for macos

### DIFF
--- a/bf_codegen/src/command.rs
+++ b/bf_codegen/src/command.rs
@@ -89,7 +89,7 @@ pub struct CommandLineDescriptor {
     #[serde(deserialize_with = "parse_command")]
     pub windows: CommandDetails,
     #[serde(deserialize_with = "parse_command")]
-    pub osx: CommandDetails,
+    pub macos: CommandDetails,
 }
 
 #[derive(Debug, Deserialize)]

--- a/bf_codegen/src/generator/mod.rs
+++ b/bf_codegen/src/generator/mod.rs
@@ -162,7 +162,7 @@ fn generate_command_line_execute(
     } else if cfg!(target_os = "linux") {
         &descriptor.linux
     } else if cfg!(target_os = "macos") {
-        &descriptor.osx
+        &descriptor.macos
     } else {
         panic!("Unsupported OS")
     };
@@ -171,9 +171,11 @@ fn generate_command_line_execute(
         "let mut call = Command::new(\"{}\");",
         &command.command_name
     ));
+
     for part in &command.parts {
         add_command_part_handling(&mut function, part);
     }
+
     function
         .line("let output = call.output()?;")
         .line("let status = output.status;")

--- a/tasks/strip.yaml
+++ b/tasks/strip.yaml
@@ -3,7 +3,7 @@ command:
   command_line:
     linux: strip [-o $destination ] $source
     windows: strip.exe [-o $destination ] $source
-    osx: strip [-o &destination ] $source
+    macos: strip [-o $destination ] $source
 element:
   tag: strip
   attributes:


### PR DESCRIPTION
- Updated names to match value of `target_os`
- Replaced `&` character with `$` that was breaking code gen in macos

Code gen in macos was generating with a missing name:

<img width="859" alt="image" src="https://github.com/glecaros/bf/assets/11056031/0208732e-8f41-4783-8768-73f101a6c922">

Line 138 of `bf_codegen/src/generator/mod.rs` is expecting a `$` token